### PR TITLE
Adding new API calls for managing user containers

### DIFF
--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/api/BaseApi.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/api/BaseApi.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.nuodb.storefront.model.dto.WorkloadStats;
+import com.nuodb.storefront.model.dto.WorkloadStep;
 import com.nuodb.storefront.model.entity.Customer;
 import com.nuodb.storefront.service.IDbApi;
 import com.nuodb.storefront.service.ISimulatorService;
@@ -22,6 +23,17 @@ public abstract class BaseApi {
 
     protected static Map<String, Map<String, WorkloadStats>> workloadStatHeap = new HashMap<>();
     protected final Object heapLock = new Object();
+
+    protected static final Map<String, String> workloadDistribution;
+    protected static int userContainerCount = 0;
+
+    static {
+        workloadDistribution = new HashMap<>();
+        workloadDistribution.put(WorkloadStep.MULTI_BROWSE.name(), "25");
+        workloadDistribution.put(WorkloadStep.MULTI_BROWSE_AND_REVIEW.name(), "25");
+        workloadDistribution.put(WorkloadStep.MULTI_SHOP.name(), "25");
+        workloadDistribution.put(WorkloadStep.ADMIN_RUN_REPORT.name(), "25");
+    }
 
     protected BaseApi() {
     }

--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/api/SimulatorApi.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/api/SimulatorApi.java
@@ -51,37 +51,6 @@ public class SimulatorApi extends BaseApi {
         getSimulator(req).removeAll();
         return Response.ok().build();
     }
-
-    @PUT
-    @Path("/workloads")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response setWorkloads(@Context HttpServletRequest req, Map<String, String> formParams) {
-        Map<String, String> workloadSettings = new HashMap<>();
-
-        for (Map.Entry<String, String> param : formParams.entrySet()) {
-            if (param.getKey().startsWith("workload-")) {
-                String workloadName = param.getKey().substring(9);
-                int quantity = Integer.parseInt(param.getValue());
-
-                if (workloadStatHeap.containsKey(NUODB_MAP_KEY) && workloadStatHeap.get(NUODB_MAP_KEY).containsKey(workloadName)) {
-                    workloadStatHeap.get(NUODB_MAP_KEY).get(workloadName).setActiveWorkerCount(quantity);
-                    workloadStatHeap.get(NUODB_MAP_KEY).get(workloadName).setActiveWorkerLimit(quantity);
-                }
-
-                workloadSettings.put(workloadName, param.getValue());
-            }
-        }
-
-        UserLauncher containerLauncher = this.buildUserLauncher(req);
-
-        try {
-			containerLauncher.launchUser(workloadSettings, 1);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-        return Response.ok().build();
-    }
     
     private UserLauncher buildUserLauncher(HttpServletRequest req) {
     	UserLauncher launcher = null;

--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/api/SimulatorApi.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/api/SimulatorApi.java
@@ -57,29 +57,36 @@ public class SimulatorApi extends BaseApi {
     @Produces(MediaType.APPLICATION_JSON)
     public Response setWorkloads(@Context HttpServletRequest req, Map<String, String> formParams) {
         Map<String, String> workloadSettings = new HashMap<>();
+
         for (Map.Entry<String, String> param : formParams.entrySet()) {
             if (param.getKey().startsWith("workload-")) {
                 String workloadName = param.getKey().substring(9);
                 int quantity = Integer.parseInt(param.getValue());
+
                 if (workloadStatHeap.containsKey(NUODB_MAP_KEY) && workloadStatHeap.get(NUODB_MAP_KEY).containsKey(workloadName)) {
                     workloadStatHeap.get(NUODB_MAP_KEY).get(workloadName).setActiveWorkerCount(quantity);
                     workloadStatHeap.get(NUODB_MAP_KEY).get(workloadName).setActiveWorkerLimit(quantity);
                 }
+
                 workloadSettings.put(workloadName, param.getValue());
             }
         }
+
         UserLauncher containerLauncher = this.buildUserLauncher(req);
+
         try {
 			containerLauncher.launchUser(workloadSettings, 1);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
         return Response.ok().build();
     }
     
     private UserLauncher buildUserLauncher(HttpServletRequest req) {
     	UserLauncher launcher = null;
     	String host = req.getHeader("HOST");
+
     	if (host.contains("localhost")) {
 			Map<String, String> dbSettings = new HashMap<>();
 			dbSettings.put("db.name", StorefrontApp.DB_NAME);
@@ -94,6 +101,7 @@ public class SimulatorApi extends BaseApi {
     	} else {
     		launcher = new LambdaLauncher();
     	}
+
     	return launcher;
     }
 
@@ -119,6 +127,54 @@ public class SimulatorApi extends BaseApi {
     @Produces(MediaType.APPLICATION_JSON)
     public Collection<WorkloadStep> getWorkloadSteps(@Context HttpServletRequest req) {
         return getSimulator(req).getWorkloadStepStats().keySet();
+    }
+
+    @POST
+    @Path("/increaseUserCount")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response increaseUserCount(@Context HttpServletRequest req) {
+        userContainerCount++;
+        UserLauncher containerLauncher = this.buildUserLauncher(req);
+
+        try {
+            containerLauncher.launchUser(workloadDistribution, 1);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/decreaseUserCount")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response decreaseUserCount(@Context HttpServletRequest req) {
+        userContainerCount--;
+        UserLauncher containerLauncher = this.buildUserLauncher(req);
+
+        try {
+            containerLauncher.launchUser(workloadDistribution, -1);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/zeroUserCount")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response zeroUserCount(@Context HttpServletRequest req) {
+        userContainerCount = 0;
+        UserLauncher containerLauncher = this.buildUserLauncher(req);
+
+        try {
+            containerLauncher.launchUser(workloadDistribution, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return Response.ok().build();
     }
 
     protected Workload lookupWorkloadByName(@Context HttpServletRequest req, String name) {

--- a/StorefrontWeb/src/main/webapp/admin/app-js/view/HeaderBar.js
+++ b/StorefrontWeb/src/main/webapp/admin/app-js/view/HeaderBar.js
@@ -141,27 +141,14 @@ Ext.define('App.view.HeaderBar', {
 
     adjustUserLoad: function(value) {
         try {
-            var frame = Ext.ComponentQuery.query('[itemId=userView]')[0];
-            if (new Date() - frame.lastLoadTime > App.app.simulatedUserPageExpiryMs) {
-                return false;
-            }
+            var url = (value == 0) ? 'zeroUserCount' : ((value > 0) ? 'increaseUserCount' : 'decreaseUserCount');
 
-            var doc = frame.getDoc();
-            if ($('#table-regions', doc).length == 0) {
-                return false;
-            }
-
-            $('input[type=number]:not([readonly])', doc).each(function() {
-                var currentVal = Math.max(0, parseInt($(this).val()));
-                
-                // Unless we're stopping all, adjust non-analyst workloads only
-                if (value == 0 || !/analyst/.test($(this).attr('name'))) {
-                    $(this).val((value > 0) ? currentVal + 25 : (value < 0) ? Math.max(0, currentVal - 25) : 0);
-                }
+            Ext.Ajax.request({
+                url: App.app.apiBaseUrl + "/api/simulator/" + url,
+                method: 'POST',
+                scope: this
             });
 
-            $('.btn-update', doc).click();
-            frame.lastLoadTime = new Date();
             return true;
         } catch (e) {
             return false;


### PR DESCRIPTION
Adding a few new API endpoints to simplify container-related calls.  This will allow us to start using default values for workload settings right now and set us up for simpler housekeeping on user containers in the future.