### PR TITLE
Custom CloudWatch Metric

### DIFF
--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/api/BaseApi.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/api/BaseApi.java
@@ -29,10 +29,10 @@ public abstract class BaseApi {
 
     static {
         workloadDistribution = new HashMap<>();
-        workloadDistribution.put(WorkloadStep.MULTI_BROWSE.name(), "25");
-        workloadDistribution.put(WorkloadStep.MULTI_BROWSE_AND_REVIEW.name(), "25");
-        workloadDistribution.put(WorkloadStep.MULTI_SHOP.name(), "25");
-        workloadDistribution.put(WorkloadStep.ADMIN_RUN_REPORT.name(), "25");
+        workloadDistribution.put(WorkloadStep.MULTI_BROWSE.name(), "525");
+        workloadDistribution.put(WorkloadStep.MULTI_BROWSE_AND_REVIEW.name(), "525");
+        workloadDistribution.put(WorkloadStep.MULTI_SHOP.name(), "525");
+        workloadDistribution.put(WorkloadStep.ADMIN_RUN_REPORT.name(), "525");
     }
 
     protected BaseApi() {


### PR DESCRIPTION
Adding a custom CloudWatch metric that is pushed every 500 calls to the stats API by user containers.  Also adjusted the workload distribution that we're hard-coding at the moment so lambda calls match what was discovered by Ben/Anton (2100 per user container).