### PR TITLE
Adding fix for trans-count < 1 on CW metric

### DIFF
--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/service/storefront/HeartbeatService.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/service/storefront/HeartbeatService.java
@@ -104,23 +104,29 @@ public class HeartbeatService implements IHeartbeatService {
             cumCwTime = cwTime;
             int totalCount = 0;
             long totalDuration = 0;
+            int tCount = 0;
+            long tDur = 0;
             Map<String, Map<String, TransactionStats>> tStats = StatsApi.getTransactionStatHeap();
 
             if (tStats.containsKey("nuodb")) {
-                int tCount = 0;
-                long tDur = 0;
-
                 synchronized (StatsApi.heapLock) {
                     for (Map.Entry<String, TransactionStats> ts : tStats.get("nuodb").entrySet()) {
                         tCount += ts.getValue().getTotalCount();
                         tDur += ts.getValue().getTotalDurationMs();
                     }
                 }
+            }
 
+            if (tCount > 0) {
                 totalCount = tCount - lastCount;
                 totalDuration = tDur - lastDuration;
                 lastCount = tCount;
                 lastDuration = tDur;
+            } else {
+                totalCount = 0;
+                totalDuration = 0;
+                lastCount = 0;
+                lastDuration = 0;
             }
 
             try {


### PR DESCRIPTION
Logic should be that if we have had 0 transactions, we have effectively stopped working, so we should reset our stats completely for reporting to the CloudWatch custom metric.