### PR TITLE
[OA-2458] Adding code for active user count and end-user pings

### DIFF
--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/api/BaseApi.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/api/BaseApi.java
@@ -5,6 +5,7 @@ package com.nuodb.storefront.api;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -30,6 +31,8 @@ public abstract class BaseApi {
     protected static int hostContainerCount = 1;
 
 	private static Map<String, Map<String, TransactionStats>> transactionStatHeap = new HashMap<>();
+
+	protected static Map<UUID, Long> userPingHeap = new HashMap<>();
 
     static {
         workloadDistribution = new HashMap<>();


### PR DESCRIPTION
There might be a more efficient way to do this, but we aren't likely to have 300 users on the same instance at any given time for now, so we can tackle that later.