### PR TITLE
cluster test in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,9 +64,14 @@ node('aml') {
         withEnv(["AWS_DEFAULT_REGION=${aws_region}", "USER=${cluster_user}"]) {
           withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: aws_credentials, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
             sh "virtualenv py27 && . py27/bin/activate && pip install -r requirements.txt"
-            sh ". py27/bin/activate && bin/cluster create --delete-after ${expiration} | tee create-output.txt"
-            output=readFile('create-output.txt').trim()
-            url=(output =~ /(http.*)/)[0][1]
+	    success=sh ". py27/bin/activate && bin/cluster create --delete-after ${expiration} | tee create-output.txt"
+	    if(success) {
+ 	       output=readFile('create-output.txt').trim()
+ 	       url=(output =~ /(http.*)/)[0][1]
+	    }
+	    else {
+	       error("Cluster failed to create")
+	    }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,10 @@
 // identify the push from a single build.
 
 def tag_prefix=env.BRANCH_NAME.replaceAll(/[^a-zA-Z0-9_]/,"_")
+aws_credentials='interactive-demo-manager'
+aws_region='us-east-2'
+expiration="2"
+cluster_user="build-${BUILD_NUMBER}"
 
 // We're currently building all steps on a single node, labeled 'aml'
 
@@ -48,4 +52,33 @@ node('aml') {
        }
      }
   }
+
+  // TODO:  Ensure that this cluster is actually using the images we just built
+    stage('Cluster Create') {
+      docker.image("python:2.7").inside {
+        withEnv(["AWS_DEFAULT_REGION=${aws_region}", "USER=${cluster_user}"]) {
+          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: aws_credentials, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+            sh "virtualenv py27 && . py27/bin/activate && pip install -r requirements.txt"
+            sh ". py27/bin/activate && bin/cluster create --delete-after ${expiration} | tee create-output.txt"
+            output=readFile('create-output.txt').trim()
+            url=(output =~ /(http.*)/)[0][1]
+          }
+        }
+      }
+    }
+
+    stage('Cluster Verify') {
+       sh "curl ${url}"
+       // TODO:  We need some kind of 'self check' URL to call
+    }
+   
+   stage('Cluster Delete') {
+      docker.image("python:2.7").inside {
+        withEnv(["AWS_DEFAULT_REGION=${aws_region}", "USER=${cluster_user}"]) {
+	  withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: aws_credentials, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+            sh "virtualenv py27 && . py27/bin/activate && pip install -r requirements.txt"
+ 	    sh ". py27/bin/activate && bin/cluster delete --include ${cluster_user}-"
+          }
+        }
+   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,9 @@ node('aml') {
  	       url=(output =~ /(http.*)/)[0][1]
 	    }
 	    else {
-	       error("Cluster failed to create")
+	      // Remove the broken cluster
+ 	      sh ". py27/bin/activate && bin/cluster delete --include ${cluster_user}-"	
+ 	      error("Cluster failed to create")
 	    }
           }
         }


### PR DESCRIPTION
Standard build process will now spin up a cluster, call cURL, and delete cluster.

We will need to substitute some reasonable URL for the cURL command to test the cluster bu this PR puts the infrastructure in place.