### PR TITLE
Fixing CFN params and startup template adjustments

### DIFF
--- a/StorefrontWeb/src/main/java/com/nuodb/storefront/service/dbapi/DbApiProxy.java
+++ b/StorefrontWeb/src/main/java/com/nuodb/storefront/service/dbapi/DbApiProxy.java
@@ -332,7 +332,13 @@ public class DbApiProxy implements IDbApi {
                 if (createDb) {
                     database = new Database();
                 }
-                boolean updateDb = fixDatabaseTemplate(database, footprint.usedRegionCount, footprint.usedHostCount, homeHostInfo);
+
+                if (footprint.usedTeHostCount < 1) {
+                    footprint.usedTeHostCount++;
+                }
+
+                boolean updateDb = fixDatabaseTemplate(database, footprint.usedRegionCount, footprint.usedTeHostCount, homeHostInfo);
+
                 if (createDb) {
                     database.name = dbConnInfo.getDbName();
                     database.username = dbConnInfo.getUsername();

--- a/cfn/ecs-cluster.cfn.json
+++ b/cfn/ecs-cluster.cfn.json
@@ -387,7 +387,7 @@
       "Type" : "AWS::ECS::Service",
       "Properties" : {
         "Cluster" : { "Ref" : "EcsClusterName" },
-        "DesiredCount" : "1",
+        "DesiredCount" : "0",
         "ServiceName" : "storefrontuser-service",
         "PlacementStrategies" : [{ "Type": "random"}],
         "TaskDefinition" : { "Ref" : "StorefrontUserTaskDefinition"},

--- a/params/demo.params
+++ b/params/demo.params
@@ -22,7 +22,7 @@ EcsClusterName: interactive-demo-dewey-20170629-152634
 
 storeFrontWebDocker: docker.io/nuodb/storefrontweb-demo:master
 storeFrontUserDocker: docker.io/nuodb/storefrontuser-demo:master
-nuodbDocker: 248317454512.dkr.ecr.us-east-1.amazonaws.com/nuodb:2.6.1-35-8-1683
+nuodbDocker: 248317454512.dkr.ecr.us-east-1.amazonaws.com/nuodb:2.6.1
 
 
 dbuser: StorefrontUser


### PR DESCRIPTION
* Changes NuoDB to be latest 2.6.1
* Changes startup user container count back to 0 (registration race issues)
* Changes startup template adjustments to be 1/1 instead of host count