### PR TITLE
Feature/separate s3 bucket paths

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -167,12 +167,40 @@ Select the clusters and then delete them in parallel.'''
     stacks = select(session, args)
     futures=[]
 
-    pool = concurrent.futures.ThreadPoolExecutor(args.parallel)
-    for stack in stacks:
-        futures.append(pool.submit(delete_cluster, stack, session, args))
-        #delete_cluster(stack, *args)
+    s3 = session.resource('s3')
+    params = read_params(args.params_file)
+
+    bucket_name = params['Bucket']
+
+
+    with  concurrent.futures.ThreadPoolExecutor(args.parallel) as pool:
+        for stack in stacks:
+            f = pool.submit(delete_cluster, stack, session, args)
+            f.add_done_callback(lambda x: delete_s3(bucket_name, stack['StackName'], s3))
+            futures.append(f)
         
     return reduce(lambda x,y: x and y, map(lambda x: x.done(), futures), True)
+
+def delete_s3(bucket_name, name, s3):
+    '''Delete the stack creation resources from s3'''
+    print "Deleting files in s3://{}/templates/{}".format(bucket_name, name)
+    prefix = "templates/{}".format(name)
+
+    bucket = s3.Bucket(bucket_name)
+    r = bucket.objects.filter(Prefix=prefix).delete()
+
+    if r == []:
+        return True
+
+    code = r[0]['ResponseMetadata']['HTTPStatusCode']
+    success = code >= 200 and code < 300
+
+    if success:
+        return True
+    else:
+        print "...deletion of files in {}/{} FAILED".format(bucket_name, name)
+        return False
+    
 
 def find_ecs_cluster(ecs, stack_name):
     '''Find the ECS cluster with the given name'''
@@ -269,15 +297,15 @@ def delete_cluster(stack, session, args):
 
 
 @cache
-def sync_to_s3(session, aws_region, bucket_name):
-    print "Copying resources to S3"
+def sync_to_s3(session, aws_region, bucket_name, name):
+    print "Copying resources to //s3/{}/templates/{}".format(bucket_name, name)
     target_dir = os.path.dirname(__file__) + "/../cfn/"
 
     s3 = session.resource('s3')
 
     for filename in os.listdir(target_dir):
         try:
-            obj = s3.Object(bucket_name, filename)
+            obj = s3.Object(bucket_name, "templates/" + name + "/" + filename)
             obj.put(Body=open(os.path.join(target_dir, filename), 'rb'))
         except Exception as e:
             print "FAILED to sync {} to {}".format(filename, bucket_name)
@@ -396,7 +424,7 @@ the command to return successfully.
             name,
             "\n   ".join(format_params(params)))
     else:
-        sync_to_s3(session, aws_region, bucket_name)
+        sync_to_s3(session, aws_region, bucket_name, name)
         cfn.create_stack(
             StackName = name,
             TemplateBody = template,
@@ -446,7 +474,6 @@ def main():
     parser.add_argument("--parallel", help="Number of operations to perform in parallel", default=40)
     parser.add_argument("--url-property", help="Name of the StorefrontURL CloudFormation export property", default="StorefrontElbURL")
 
-
     selectParser = argparse.ArgumentParser(add_help=False)
 
     selectParser.add_argument("--all", help="include all stacks", action='store_true', default=False)
@@ -458,15 +485,21 @@ def main():
     selectParser.add_argument("--no-filter-names", help="Do not filter the stacks by the conventional naming pattern", action='store_true')
 
 
+    fileChoiceParser = argparse.ArgumentParser(add_help=False)
+    fileChoiceParser.add_argument("--params-file", help="Parameters file", default="params/demo.params")
+    fileChoiceParser.add_argument("--template", help="CFN Template file", default="cfn/demo.cfn.json")
+
+
+
     subs = parser.add_subparsers(help='sub-command help')
 
-    parse_create = subs.add_parser('create', help='Create one or more clusters')
+    parse_create = subs.add_parser('create', help='Create one or more clusters', parents=[fileChoiceParser])
     parse_create.set_defaults(function=create_clusters)
 
     parse_list = subs.add_parser('list', help='List clusters', parents=[selectParser])
     parse_list.set_defaults(function=list_clusters)
 
-    parse_delete = subs.add_parser('delete', help='Delete clusters', parents=[selectParser])
+    parse_delete = subs.add_parser('delete', help='Delete clusters', parents=[selectParser, fileChoiceParser])
     parse_delete.set_defaults(function=delete_clusters)
 
     def check_delete_after (x):
@@ -479,8 +512,6 @@ def main():
     parse_create.add_argument("--prefix", help="cluster name prefix", nargs=1, default='interactive-demo')
     parse_create.add_argument("--no-wait", help="Do not wait for cluster completion", action='store_true')
     parse_create.add_argument("--dry-run", help="Do not actually create the stack", action='store_true')
-    parse_create.add_argument("--params-file", help="Parameters file", default="params/demo.params")
-    parse_create.add_argument("--template", help="CFN Template file", default="cfn/demo.cfn.json")
     parse_create.add_argument("--delete-after", help="Hours until the cluster should be deleted", type=check_delete_after)
 
     group = parse_create.add_mutually_exclusive_group()

--- a/bin/cluster
+++ b/bin/cluster
@@ -98,6 +98,9 @@ This should be used by any function selecting clusters to implement --include an
 
     stacks = result['StackSummaries']
 
+    if not args.no_filter_names:
+        stacks = [x for x in stacks if re.match("^.*\\d+-\\d+$", x['StackName'])]
+
     if args.all:
         pass
     elif not args.include and not args.exclude:
@@ -496,6 +499,7 @@ def main():
         p.add_argument("--expired", help="include only expired stacks", action='store_true', default=False)
         p.add_argument("--failed", help="include only stacks with failed operations", action='store_true', default=False)
         p.add_argument("--status", help="include only stacks with the given word in the status")
+        p.add_argument("--no-filter-names", help="Do not filter the stacks by the conventional naming pattern", action='store_true')
 
     args = parser.parse_args()
 

--- a/bin/cluster
+++ b/bin/cluster
@@ -264,13 +264,18 @@ def delete_cluster(stack, session, args):
         return False
 
 
-def sync_to_s3(aws_region, bucket_naame):
+def sync_to_s3(session, aws_region, bucket_naame):
     target_dir = os.path.dirname(__file__) + "/../cfn/"
 
-    s3 = boto3.resource('s3', region_name=aws_region)
+    s3 = session.resource('s3')
 
     for filename in os.listdir(target_dir):
-        s3.Object(bucket_name, filename).put(Body=open(os.path.join(target_dir, filename), 'rb'))
+        try:
+            obj = s3.Object(bucket_name, filename)
+            obj.put(Body=open(os.path.join(target_dir, filename), 'rb'))
+        except Exception as e:
+            print "FAILED to sync {} to {}".format(filename, bucket_name)
+            raise e
 
 
 def create_cluster_name(number, args):
@@ -390,7 +395,7 @@ the command to return successfully.
     aws_region = params['BucketRegion']
     bucket_name = params['Bucket']
 
-    sync_to_s3(aws_region, bucket_name)
+    sync_to_s3(session, aws_region, bucket_name)
 
     if args.delete_after:
         tags.append(dict(Key='DeleteAfter',

--- a/bin/cluster
+++ b/bin/cluster
@@ -267,7 +267,9 @@ def delete_cluster(stack, session, args):
         return False
 
 
-def sync_to_s3(session, aws_region, bucket_naame):
+@cache
+def sync_to_s3(session, aws_region, bucket_name):
+    print "Copying resources to S3"
     target_dir = os.path.dirname(__file__) + "/../cfn/"
 
     s3 = session.resource('s3')
@@ -392,13 +394,8 @@ the command to return successfully.
         ]
 
     # Upload cfn templates to s3 bucket
-    global aws_region
-    global bucket_name
-
     aws_region = params['BucketRegion']
     bucket_name = params['Bucket']
-
-    sync_to_s3(session, aws_region, bucket_name)
 
     if args.delete_after:
         tags.append(dict(Key='DeleteAfter',
@@ -411,6 +408,7 @@ the command to return successfully.
             name,
             "\n   ".join(format_params(params)))
     else:
+        sync_to_s3(session, aws_region, bucket_name)
         cfn.create_stack(
             StackName = name,
             TemplateBody = template,

--- a/bin/cluster
+++ b/bin/cluster
@@ -57,6 +57,7 @@ def list_clusters(session, args):
 Select clusters using common 'select' method and print them out'''
 
     print_stack_info(session, args, select(session, args))
+    return True
 
 def print_stack_info(session, args, stacks):
     ''' Given a list of stacks from cloudformation, print the info for each stack'''
@@ -171,7 +172,7 @@ Select the clusters and then delete them in parallel.'''
         futures.append(pool.submit(delete_cluster, stack, session, args))
         #delete_cluster(stack, *args)
         
-    reduce(lambda x,y: x and y, map(lambda x: x.done(), futures), True)
+    return reduce(lambda x,y: x and y, map(lambda x: x.done(), futures), True)
 
 def find_ecs_cluster(ecs, stack_name):
     '''Find the ECS cluster with the given name'''
@@ -295,36 +296,23 @@ def create_clusters(session, args):
 
 Create one or more clusters as requested
 '''
-    names=[]
-    futures=[]
+    pool = concurrent.futures.ThreadPoolExecutor(args.parallel)
+    cf = session.client("cloudformation")
+    cfr = session.resource("cloudformation")
 
-
-    for number in range(1, args.count+1):
-        names.append(create_cluster_name(number, args))
+    names = map(lambda number: create_cluster_name(number, args), range(1, args.count+1))
 
     for name in names:
         create_cluster(name, session, args)
 
-    futures=[]
+    statuses = pool.map(lambda name: wait_for_stack(name, cf, cfr, args), names)
 
-    cf = session.client("cloudformation")
-    cfr = session.resource("cloudformation")
-
-    pool = concurrent.futures.ThreadPoolExecutor(args.parallel)
-
-    for name in names:
-        def status(x):
-            pass
-#            print x.result()
-
-        future = pool.submit(wait_for_stack,name,cf, cfr,args)
-#        future.add_done_callback(status)
-        futures.append(future)
-
-    if not reduce(lambda x,y: x and y, map(lambda x: x.done(), futures), True):
-        sys.exit(1)
-#        map(lambda x: status(x), futures)
-
+    bye=True
+    for i, result in enumerate(statuses):
+        print "Waiting for {} returned {}".format(names[i], result)
+        bye=False
+        
+    return bye
 
 @cache
 def read_params(file):
@@ -443,7 +431,6 @@ args -- command line arguments
                for y in stack.outputs 
                if y['OutputKey'] == args.url_property]
         print "{}: SUCCESS -- {}".format(name, url[0])
-
         return True
                  
     except:
@@ -506,7 +493,10 @@ def main():
     else:
         session = boto3.Session()
 
-    args.function(session, args)
+    if args.function(session, args):
+        sys.exit(0)
+    else:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/bin/cluster
+++ b/bin/cluster
@@ -446,15 +446,27 @@ def main():
     parser.add_argument("--parallel", help="Number of operations to perform in parallel", default=40)
     parser.add_argument("--url-property", help="Name of the StorefrontURL CloudFormation export property", default="StorefrontElbURL")
 
+
+    selectParser = argparse.ArgumentParser(add_help=False)
+
+    selectParser.add_argument("--all", help="include all stacks", action='store_true', default=False)
+    selectParser.add_argument("--include", help="include clusters containing", nargs=1)
+    selectParser.add_argument("--exclude", help="exclude clusters containing", nargs=1)
+    selectParser.add_argument("--expired", help="include only expired stacks", action='store_true', default=False)
+    selectParser.add_argument("--failed", help="include only stacks with failed operations", action='store_true', default=False)
+    selectParser.add_argument("--status", help="include only stacks with the given word in the status")
+    selectParser.add_argument("--no-filter-names", help="Do not filter the stacks by the conventional naming pattern", action='store_true')
+
+
     subs = parser.add_subparsers(help='sub-command help')
 
     parse_create = subs.add_parser('create', help='Create one or more clusters')
     parse_create.set_defaults(function=create_clusters)
 
-    parse_list = subs.add_parser('list', help='List clusters')
+    parse_list = subs.add_parser('list', help='List clusters', parents=[selectParser])
     parse_list.set_defaults(function=list_clusters)
 
-    parse_delete = subs.add_parser('delete', help='Delete clusters')
+    parse_delete = subs.add_parser('delete', help='Delete clusters', parents=[selectParser])
     parse_delete.set_defaults(function=delete_clusters)
 
     def check_delete_after (x):
@@ -476,15 +488,6 @@ def main():
     group.add_argument("--suffix", help="cluster name suffix.  Default is a timestamp")
     group.add_argument("--key-name", help="SSH key name for instance", default="interactive-demo")
 
-    # This shoud, perhaps, be a parent parser
-    for p in [parse_list, parse_delete]:
-        p.add_argument("--all", help="include all stacks", action='store_true', default=False)
-        p.add_argument("--include", help="include clusters containing", nargs=1)
-        p.add_argument("--exclude", help="exclude clusters containing", nargs=1)
-        p.add_argument("--expired", help="include only expired stacks", action='store_true', default=False)
-        p.add_argument("--failed", help="include only stacks with failed operations", action='store_true', default=False)
-        p.add_argument("--status", help="include only stacks with the given word in the status")
-        p.add_argument("--no-filter-names", help="Do not filter the stacks by the conventional naming pattern", action='store_true')
 
     args = parser.parse_args()
 

--- a/bin/cluster
+++ b/bin/cluster
@@ -469,13 +469,19 @@ def main():
     parse_delete = subs.add_parser('delete', help='Delete clusters')
     parse_delete.set_defaults(function=delete_clusters)
 
+    def check_delete_after (x):
+        if x.endswith('h'):
+            return x
+        else:
+            raise argparse.ArgumentTypeError("--delete-after must end in 'h'")
+
     parse_create.add_argument("--user", help="user name to include in cluster name", nargs=1, default=os.environ['USER'])
     parse_create.add_argument("--prefix", help="cluster name prefix", nargs=1, default='interactive-demo')
     parse_create.add_argument("--no-wait", help="Do not wait for cluster completion", action='store_true')
     parse_create.add_argument("--dry-run", help="Do not actually create the stack", action='store_true')
     parse_create.add_argument("--params-file", help="Parameters file", default="params/demo.params")
     parse_create.add_argument("--template", help="CFN Template file", default="cfn/demo.cfn.json")
-    parse_create.add_argument("--delete-after", help="Hours until the cluster should be deleted")
+    parse_create.add_argument("--delete-after", help="Hours until the cluster should be deleted", type=check_delete_after)
 
     group = parse_create.add_mutually_exclusive_group()
     group.add_argument("--count", help="number of clusters to create", type=int,  default=1)

--- a/cfn/demo.cfn.json
+++ b/cfn/demo.cfn.json
@@ -203,6 +203,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/vpc.cfn.json"
         ]]},
         "Parameters" : {
@@ -217,6 +219,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/resources.cfn.json"
         ]]},
         "Parameters" : {
@@ -232,6 +236,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/elk-logging.cfn.json"
         ]]},
         "Parameters" : {
@@ -257,6 +263,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/loadbalancers.cfn.json"
         ]]},
         "Parameters" : {
@@ -280,6 +288,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/lambda-functions.cfn.json"
         ]]},
         "Parameters" : {
@@ -303,6 +313,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/ecs-cluster.cfn.json"
         ]]},
         "Parameters" : {
@@ -348,6 +360,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/nuodb-on-ec2.cfn.json"
         ]]},
         "Parameters" : {
@@ -384,6 +398,8 @@
         "TemplateURL" : { "Fn::Join" : ["", [
           { "Fn::FindInMap" : [ "S3Endpoints", { "Ref" : "AWS::Region" },  "Endpoint" ] } ,
           {"Ref" : "Bucket"},
+	  "/templates/",
+          {"Ref" : "AWS::StackName"},
           "/nuodb-on-ecs.cfn.json"
         ]]},
         "Parameters" : {


### PR DESCRIPTION
This PR also includes #154 

Put all CFN template files in a stack-specific S3 path.  Also, deletes files on cluster deletion.

This PR does *NOT* change the paths for ELK and other logging into the S3 bucket -- those should likely be changed as well in a different PR which also modifies the cluster script to delete them appropriately.